### PR TITLE
use process.cwd() for default sourceRoot

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -42,6 +42,7 @@ if (file && file !== '-') {
 } 
 
 var config = argv.config ? JSON.parse(fs.readFileSync(argv.config, 'utf8')) : {};
+config.sourceRoot = config.sourceRoot || process.cwd();
 
 if (argv['incoming-sourcemap']) {
     config.sourceMap = JSON.parse(fs.readFileSync(argv['incoming-sourcemap'], 'utf8'));

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "bugs": "https://github.com/power-assert-js/espower-cli/issues",
   "dependencies": {
     "concat-stream": "^1.5.0",
-    "espower-source": "git://github.com/power-assert-js/espower-source.git#source-root",
+    "espower-source": "git://github.com/power-assert-js/espower-source.git",
     "minimist": "^1.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "bugs": "https://github.com/power-assert-js/espower-cli/issues",
   "dependencies": {
     "concat-stream": "^1.5.0",
-    "espower-source": "^0.10.0",
+    "espower-source": "git://github.com/power-assert-js/espower-source.git#source-root",
     "minimist": "^1.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "bugs": "https://github.com/power-assert-js/espower-cli/issues",
   "dependencies": {
     "concat-stream": "^1.5.0",
-    "espower-source": "git://github.com/power-assert-js/espower-source.git",
+    "espower-source": "^1.0.0",
     "minimist": "^1.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,10 +34,7 @@
     "test",
     "testing"
   ],
-  "license": {
-    "type": "MIT",
-    "url": "http://twada.mit-license.org/"
-  },
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/power-assert-js/espower-cli.git"

--- a/test/espower_cli_test.js
+++ b/test/espower_cli_test.js
@@ -20,6 +20,15 @@ describe('espower-cli', function () {
         }));
     });
 
+    it('when filepath is absolute', function (done) {
+        var expected = fs.readFileSync('test/expected/example.js', 'utf8');
+        var proc = child.spawn(this.executable, [path.join(process.cwd(), 'test', 'fixtures', 'example.js')]);
+        proc.stdout.pipe(concat(function (output) {
+            assert.equal(output.toString('utf8'), expected);
+            done();
+        }));
+    });
+
     describe('option for configuration', function () {
         beforeEach(function () {
             var expected = fs.readFileSync('test/expected/customized.js', 'utf8');

--- a/test/expected/merged-sourcemap.js
+++ b/test/expected/merged-sourcemap.js
@@ -33,7 +33,7 @@ describe('various types', function () {
         bob = new Person('bob', 5);
         return assert(assert._expr(assert._capt(assert._capt(assert._capt(assert._capt(this.types, 'arguments/0/left/object/object')[assert._capt(index, 'arguments/0/left/object/property')], 'arguments/0/left/object').name, 'arguments/0/left') === assert._capt(assert._capt(bob, 'arguments/0/right/object').name, 'arguments/0/right'), 'arguments/0'), {
             content: 'assert(this.types[index].name === bob.name)',
-            filepath: '/absolute/path/to/coffee_script_test.coffee',
+            filepath: 'coffee_script_test.coffee',
             line: 33
         }));
     });


### PR DESCRIPTION
Dealing with `sourceRoot` option to display relative paths, and produce correct SourceMap.

Related topics:

- [sourceRoot option by twada · Pull Request #7 · power-assert-js/espower-source](https://github.com/power-assert-js/espower-source/pull/7)
- [sourceRoot option by twada · Pull Request #18 · power-assert-js/espower](https://github.com/power-assert-js/espower/pull/18)
- [convert relative filepath for security reason · Issue #20 · power-assert-js/power-assert](https://github.com/power-assert-js/power-assert/issues/20)